### PR TITLE
get_jtemp: Reverse ordering of Lat and Lon passed to SpatialPoints

### DIFF
--- a/WaterBalance/R/WB_Functions.R
+++ b/WaterBalance/R/WB_Functions.R
@@ -17,7 +17,7 @@
 get_jtemp = function(Lat, Lon){
   j.raster = raster::raster(system.file("extdata","merged_jennings2.tif", package="WaterBalance")) 
   projection = sp::CRS("+init=epsg:4326")
-  coords = cbind(Lat, Lon)
+  coords = cbind(Lon, Lat)
   sp = sp::SpatialPoints(coords, proj4string = projection)
   jtemp = raster::extract(j.raster, sp)
   return(jtemp)

--- a/WaterBalance/R/WB_Functions.R
+++ b/WaterBalance/R/WB_Functions.R
@@ -14,7 +14,7 @@
 #' @export
 #' get_jtemp()
 
-get_jtemp = function(Lat, Lon){
+get_jtemp = function(Lon, Lat){
   j.raster = raster::raster(system.file("extdata","merged_jennings2.tif", package="WaterBalance")) 
   projection = sp::CRS("+init=epsg:4326")
   coords = cbind(Lon, Lat)


### PR DESCRIPTION
Running get_jtemp returns NA for coordinates that have values on the merged_jennings2.tif raster.  sp::SpatialPoints expects coordinates in the order Longitude, Latitude.  This reverses the order of the coordinates passed to sp::SpatialPoints so that get_jtemp now returns values.

`
> Lat
[1] 39.9098
> Lon
[1] 114.4138
 > get_jtemp
function(Lat, Lon){
  j.raster = raster::raster(system.file("extdata","merged_jennings2.tif", package="WaterBalance")) 
  projection = sp::CRS("+init=epsg:4326")
  coords = cbind(Lat, Lon)
  sp = sp::SpatialPoints(coords, proj4string = projection)
  jtemp = raster::extract(j.raster, sp)
  return(jtemp)
}
> get_jtemp(Lat, Lon)
     [,1]
[1,]   NA
get_jtemp
function(Lat, Lon){
  j.raster = raster::raster(system.file("extdata","merged_jennings2.tif", package="WaterBalance")) 
  projection = sp::CRS("+init=epsg:4326")
  coords = cbind(Lon, Lat)
  sp = sp::SpatialPoints(coords, proj4string = projection)
  jtemp = raster::extract(j.raster, sp)
  return(jtemp)
}
> get_jtemp(Lat, Lon)         
2.625192 

`

